### PR TITLE
Add 5 flights on Aug 5th, 6th and 1 event on Aug 5th, for demo purpose.

### DIFF
--- a/flight-plugin/events.json
+++ b/flight-plugin/events.json
@@ -1,6 +1,6 @@
 [
   {
-    "event": "Product update meeting",
+    "event": "Product Update Meeting",
     "meetingStart": "Mon, 18 Mar 2024 09:00:00",
     "meetingEnd": "Mon, 18 Mar 2024 17:00:00"
   },
@@ -8,5 +8,10 @@
     "event": "Hackathon Daily Sync",
     "meetingStart": "Tue, 19 Mar 2024 10:30:00",
     "meetingEnd": "Tue, 19 Mar 2024 11:00:00"
+  },
+  {
+    "event": "Product Update Meeting",
+    "meetingStart": "Mon, 05 Aug 2024 10:00:00",
+    "meetingEnd": "Mon, 05 Aug 2024 12:00:00"
   }
 ]

--- a/flight-plugin/flights.json
+++ b/flight-plugin/flights.json
@@ -180,5 +180,70 @@
       "price": 148,
       "duration": "5hr 10min",
       "ticket_link": "https://www.alaskaair.com/Shopping/Cart/AddNewFlight?A=1&C=0&SITE_PREF=full&FT=ow&F1=SEA|EWR|06/24/2024|298,AS|S&FARE=328.10&frm=cart&meta=GOO_CS_X&utm_source=google&utm_medium=meta&utm_campaign=book_as_site&gclid=ADowPOLtFfNxtvACtdtpSZdejO4pd-Ue96hIi0f6KRUwK3CCH2Y0dYwts3I4Gt1C4DpHSY4sPCFX1cNVgDQrwvpqDv4-yhxo5ZOEFBE4tyWhatqfnTo&gclsrc=gf"
-    }
+    },
+    {
+      "airline": "Alaska Airlines",
+      "flight_number": "AS398",
+      "departure_airport": "SEA",
+      "destination_airport": "EWR",
+      "departure_time": "Mon, 05 August 2024 10:06:00",
+      "arrival_time": "Mon, 05 August 2024 18:28:00",
+      "connections": 0,
+      "class": "Economy",
+      "price": 559,
+      "duration": "5hr 22min",
+      "ticket_link": "https://www.alaskaair.com/search/results?O=SEA&D=EWR&OD=2024-08-05&A=1&C=0&L=0&RT=false"
+    },
+    {
+      "airline": "United Airlines",
+      "flight_number": "UA1742",
+      "departure_airport": "SEA",
+      "destination_airport": "EWR",
+      "departure_time": "Mon, 05 August 2024 06:00:00",
+      "arrival_time": "Mon, 05 August 2024 14:12:00",
+      "connections": 0,
+      "class": "Economy",
+      "price": 273,
+      "duration": "5hr 22min",
+      "ticket_link": "https://www.united.com/en/us/traveler/choose-travelers?cartId=E2AE52DB-A441-4535-A273-E6E5B7CC97B3&tqp=R"
+    },
+    {
+      "airline": "United Airlines",
+      "flight_number": "UA1631,UA2127",
+      "departure_airport": "SEA",
+      "destination_airport": "EWR",
+      "departure_time":  "Mon, 05 August 2024 23:35:00",
+      "arrival_time":  "Tue, 06 August 2024 09:51:00",
+      "connections": 1,
+      "class": "Economy",
+      "price": 200.92,
+      "duration": "7hr 16min",
+      "ticket_link": "https://www.united.com/en/us/traveler/choose-travelers?cartId=F72090DD-B855-42CE-82E9-EB33E53C86EE&tqp=R"
+    },
+    {
+      "airline": "United Airlines",
+      "flight_number": "UA1742",
+      "departure_airport": "SEA",
+      "destination_airport": "EWR",
+      "departure_time": "Tue, 06 August 2024 06:20:00",
+      "arrival_time": "Tue, 06 August 2024 14:32:00",
+      "connections": 0,
+      "class": "Economy",
+      "price": 208.09,
+      "duration": "5hr 12min",
+      "ticket_link": "https://www.united.com/en/us/traveler/choose-travelers?cartId=4C86DF46-E459-4C9A-8549-6CFA6C48760E&tqp=R"
+    },
+    {
+      "airline": "Delta Airlines",
+      "flight_number": "DL790, DL2567",
+      "departure_airport": "SEA",
+      "destination_airport": "EWR",
+      "departure_time":  "Tue, 06 August 2024 09:53:00",
+      "arrival_time":  "Tue, 06 August 2024 19:29:00",
+      "connections": 1,
+      "class": "Economy",
+      "price": 287.6,
+      "duration": "7hr 16min",
+      "ticket_link": "https://www.bing.com/travel/flight-search?src=SEA&des=EWR&ddate=2024-08-06&isr=0&rdate=2024-08-06&sel=&cls=0&adult=1&child=0&infant=0&FORM=FBL1YC&as=1&ad=0&serpig=&flt=&fltName=&ignrrec=0&hubpage=0&dSugg=0&serp=1&srt=&numberofstops=&scenario=&q=flights+from+SEA-EWR&entrypoint=FBL1YC"
+    } 
 ]


### PR DESCRIPTION
I added 3 flights on Aug 5th, 2 flights on Aug 6th, and 1 event on Aug 5th, 10:00 - 12:00
For demo purpose, we can say:

I have a business trip to New York, plan to go on Aug 5th Monday, or Aug 6th Tuesday. Then Copilot will return 5 mock flights:
(1) "Alaska Airlines" Monday 10-18, non-stop, conflict with meeting so cannot choose
(2) "United Airlines" Monday 6-2, non-stop, cheaper than Alaska, but conflict with meeting so cannot choose
(3) "United Airlines" Monday - Tuesday morning, 1 stop and over night, the cheapest but pass
**(4) "United Airlines" Tuesday 6-2, non-stop, cheaper, no conflict, choose this one, and the UA link should direct to the ticket page.**
(5) "Delta Airlines", Tuesday 9-19, one-stop, expensive than (4), pass.